### PR TITLE
OW-U-21: Łączenie się z backendem poprzez proxy, zamiast przez CORS

### DIFF
--- a/openpkw-kalkulator-obwodowy-web/etc/apache2/sites-available/openpkw-weryfikator-frontend.conf
+++ b/openpkw-kalkulator-obwodowy-web/etc/apache2/sites-available/openpkw-weryfikator-frontend.conf
@@ -3,4 +3,7 @@
 	DocumentRoot /var/www/html/openpkw-weryfikator-frontend
 	ErrorLog ${APACHE_LOG_DIR}/error.log
 	CustomLog ${APACHE_LOG_DIR}/access.log combined
+
+        ProxyPass /api/openpkw http://rumcajs.open-pkw.pl:9080/openpkw
+        ProxyPassReverse /api/openpkw http://rumcajs.open-pkw.pl:9080/openpkw
 </VirtualHost>

--- a/openpkw-weryfikator-frontend-docker/Dockerfile
+++ b/openpkw-weryfikator-frontend-docker/Dockerfile
@@ -28,5 +28,7 @@ RUN a2dissite 000-default.conf &&\
 
 RUN sudo service ssh start
 
+RUN a2enmod proxy_http
+
 EXPOSE 80
 EXPOSE 22

--- a/openpkw-weryfikator-frontend-docker/etc/apache2/sites-available/openpkw-weryfikator-frontend.conf
+++ b/openpkw-weryfikator-frontend-docker/etc/apache2/sites-available/openpkw-weryfikator-frontend.conf
@@ -3,4 +3,7 @@
 	DocumentRoot /var/www/html/openpkw-weryfikator-frontend
 	ErrorLog ${APACHE_LOG_DIR}/error.log
 	CustomLog ${APACHE_LOG_DIR}/access.log combined
+
+        ProxyPass /api/openpkw http://rumcajs.open-pkw.pl:9080/openpkw
+        ProxyPassReverse /api/openpkw http://rumcajs.open-pkw.pl:9080/openpkw
 </VirtualHost>


### PR DESCRIPTION
Zmiany obejmują trzy projekty:
- openpkw-devops
- openpkw-weryfikator-frontend
- openpkw-weryfikator-backend

W projekcie openpkw-devops są dwie zmiany:
1. Włączenie mod-proxy w serwerze Apache.
2. Skonfigurowanie proxy dla Weryfikatora OpenPKW.
